### PR TITLE
Fix: support newer OpenAI models (gpt-5, o1, o3 series)

### DIFF
--- a/tests/ai_tests.rs
+++ b/tests/ai_tests.rs
@@ -1,6 +1,7 @@
 use httpmock::Method::POST;
 use httpmock::MockServer;
 use qqqa::ai::ChatClient;
+use serde_json::Value;
 use std::net::TcpListener;
 
 fn sandbox_blocks_binding() -> bool {
@@ -53,5 +54,141 @@ async fn chat_stream_streams_tokens() {
         .await
         .unwrap();
     assert_eq!(acc, "Hello");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn gpt5_mini_uses_max_completion_tokens() {
+    if sandbox_blocks_binding() {
+        eprintln!("[skip] sandbox blocks binding to 127.0.0.1; skipping httpmock test");
+        return;
+    }
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat/completions")
+            .json_body_partial(r#"{"model":"gpt-5-mini"}"#)
+            .matches(|req| {
+                // Verify that the body contains max_completion_tokens and NOT max_tokens
+                // Also verify that temperature is NOT included (gpt-5 doesn't support it)
+                if let Some(body_bytes) = &req.body {
+                    if let Ok(body) = serde_json::from_slice::<Value>(body_bytes) {
+                        return body.get("max_completion_tokens").is_some()
+                            && body.get("max_tokens").is_none()
+                            && body.get("temperature").is_none();
+                    }
+                }
+                false
+            });
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"choices":[{"message":{"content":"GPT-5 response"}}]}"#);
+    });
+
+    let client = ChatClient::new(server.base_url(), "test".into()).unwrap();
+    let got = client.chat_once("gpt-5-mini", "Hi", true).await.unwrap();
+    assert_eq!(got, "GPT-5 response");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn gpt4_uses_max_tokens() {
+    if sandbox_blocks_binding() {
+        eprintln!("[skip] sandbox blocks binding to 127.0.0.1; skipping httpmock test");
+        return;
+    }
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat/completions")
+            .json_body_partial(r#"{"model":"gpt-4"}"#)
+            .matches(|req| {
+                // Verify that the body contains max_tokens and NOT max_completion_tokens
+                // Also verify that temperature IS included (older models support it)
+                if let Some(body_bytes) = &req.body {
+                    if let Ok(body) = serde_json::from_slice::<Value>(body_bytes) {
+                        return body.get("max_tokens").is_some()
+                            && body.get("max_completion_tokens").is_none()
+                            && body.get("temperature").is_some();
+                    }
+                }
+                false
+            });
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"choices":[{"message":{"content":"GPT-4 response"}}]}"#);
+    });
+
+    let client = ChatClient::new(server.base_url(), "test".into()).unwrap();
+    let got = client.chat_once("gpt-4", "Hi", true).await.unwrap();
+    assert_eq!(got, "GPT-4 response");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn o1_preview_uses_max_completion_tokens() {
+    if sandbox_blocks_binding() {
+        eprintln!("[skip] sandbox blocks binding to 127.0.0.1; skipping httpmock test");
+        return;
+    }
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat/completions")
+            .json_body_partial(r#"{"model":"o1-preview"}"#)
+            .matches(|req| {
+                // Verify that the body contains max_completion_tokens and NOT max_tokens
+                // Also verify that temperature is NOT included (gpt-5 doesn't support it)
+                if let Some(body_bytes) = &req.body {
+                    if let Ok(body) = serde_json::from_slice::<Value>(body_bytes) {
+                        return body.get("max_completion_tokens").is_some()
+                            && body.get("max_tokens").is_none()
+                            && body.get("temperature").is_none();
+                    }
+                }
+                false
+            });
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"choices":[{"message":{"content":"O1 response"}}]}"#);
+    });
+
+    let client = ChatClient::new(server.base_url(), "test".into()).unwrap();
+    let got = client.chat_once("o1-preview", "Hi", true).await.unwrap();
+    assert_eq!(got, "O1 response");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn o3_mini_uses_max_completion_tokens() {
+    if sandbox_blocks_binding() {
+        eprintln!("[skip] sandbox blocks binding to 127.0.0.1; skipping httpmock test");
+        return;
+    }
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat/completions")
+            .json_body_partial(r#"{"model":"o3-mini"}"#)
+            .matches(|req| {
+                // Verify that the body contains max_completion_tokens and NOT max_tokens
+                // Also verify that temperature is NOT included (gpt-5 doesn't support it)
+                if let Some(body_bytes) = &req.body {
+                    if let Ok(body) = serde_json::from_slice::<Value>(body_bytes) {
+                        return body.get("max_completion_tokens").is_some()
+                            && body.get("max_tokens").is_none()
+                            && body.get("temperature").is_none();
+                    }
+                }
+                false
+            });
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"choices":[{"message":{"content":"O3 response"}}]}"#);
+    });
+
+    let client = ChatClient::new(server.base_url(), "test".into()).unwrap();
+    let got = client.chat_once("o3-mini", "Hi", true).await.unwrap();
+    assert_eq!(got, "O3 response");
     mock.assert();
 }


### PR DESCRIPTION
I installed qqqa on my macOS system, ran `qq --init`, and chose profile 2: `OpenAI — gpt-5-mini (slower, a bit smarter)`.

I then provided a valid OpenAI API key, and ran `qq "what is a unix system?".

This resulted in the following error:

```shell
Error: API error (400 Bad Request): {
  "error": {
    "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
    "type": "invalid_request_error",
    "param": "max_tokens",
    "code": "unsupported_parameter"
  }
}
```

After fixing this issue (see below), another error occurred:

```shell
Error: API error (400 Bad Request): {
  "error": {
    "message": "Unsupported value: 'temperature' does not support 0.0 with this model. Only the default (1) value is supported.",
    "type": "invalid_request_error",
    "param": "temperature",
    "code": "unsupported_value"
  }
}
```

The problem was that newer OpenAI models require two API parameter changes:

1. max_completion_tokens: gpt-5/o1/o3 models reject the legacy "max_tokens" parameter. They require "max_completion_tokens" instead. Error: "Unsupported parameter: 'max_tokens' is not supported"

2. temperature: gpt-5/o1/o3 models only support the default temperature value (1.0) and reject custom values like 0.0. Error: "Unsupported value: 'temperature' does not support 0.0"

Changes:
- Added max_tokens_param() to determine correct parameter name by model
- Added supports_temperature() to check temperature compatibility
- Updated all 5 API methods to use dynamic parameters
- Added 4 tests verifying correct behavior for gpt-5, gpt-4, o1, o3

Older models (gpt-4, gpt-3.5-turbo) continue to use max_tokens with temperature=0.0. All existing tests pass.