### PR TITLE
Fix / support newer OpenAI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ Defaults written to `~/.qq/config.json`:
 - Profiles
   - `openai` → model `gpt-5-mini`
   - `groq` → model `openai/gpt-oss-20b` (default)
+- Optional per-profile `reasoning_effort` for GPT-5 family models. If you leave it unset, qqqa sends `"reasoning_effort": "minimal"` for any `gpt-5*` model to keep responses fast. Set it to `"low"`, `"medium"`, or `"high"` when you want deeper reasoning.
+
+Example override in `~/.qq/config.json`:
+
+```json
+{
+  "profiles": {
+    "openai": {
+      "model_provider": "openai",
+      "model": "gpt-5-mini",
+      "reasoning_effort": "medium"
+    }
+  }
+}
+```
 
 - Optional flag: `no_emoji` (unset by default). Set via `qq --no-fun` or `qa --no-fun`.
 

--- a/src/bin/qa.rs
+++ b/src/bin/qa.rs
@@ -144,7 +144,8 @@ async fn main() -> Result<()> {
         &task,
     );
 
-    let client = ChatClient::new(eff.base_url, eff.api_key)?;
+    let client = ChatClient::new(eff.base_url.clone(), eff.api_key.clone())?
+        .with_reasoning_effort(eff.reasoning_effort.clone());
     // Provide tool specs so the API can emit structured tool_calls instead of erroring.
     let tools_spec = serde_json::json!([
         {

--- a/src/bin/qq.rs
+++ b/src/bin/qq.rs
@@ -159,7 +159,8 @@ async fn main() -> Result<()> {
     );
 
     // Prepare HTTP client.
-    let client = ChatClient::new(eff.base_url, eff.api_key)?;
+    let client = ChatClient::new(eff.base_url.clone(), eff.api_key.clone())?
+        .with_reasoning_effort(eff.reasoning_effort.clone());
 
     // Stream or buffered request per flag.
     if cli.stream {

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct ModelProvider {
 pub struct Profile {
     pub model_provider: String,
     pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,6 +93,7 @@ impl Default for Config {
             Profile {
                 model_provider: "openai".to_string(),
                 model: "gpt-5-mini".to_string(),
+                reasoning_effort: None,
             },
         );
         profiles.insert(
@@ -98,6 +101,7 @@ impl Default for Config {
             Profile {
                 model_provider: "groq".to_string(),
                 model: "openai/gpt-oss-20b".to_string(),
+                reasoning_effort: None,
             },
         );
         profiles.insert(
@@ -105,6 +109,7 @@ impl Default for Config {
             Profile {
                 model_provider: "anthropic".to_string(),
                 model: "claude-3-5-sonnet-20241022".to_string(),
+                reasoning_effort: None,
             },
         );
 
@@ -126,6 +131,7 @@ pub struct EffectiveProfile {
     pub model: String,
     pub base_url: String,
     pub api_key: String,
+    pub reasoning_effort: Option<String>,
 }
 
 impl Config {
@@ -243,6 +249,7 @@ impl Config {
             model,
             base_url,
             api_key,
+            reasoning_effort: profile.reasoning_effort.clone(),
         })
     }
 

--- a/tests/ai_tests.rs
+++ b/tests/ai_tests.rs
@@ -2,8 +2,8 @@ use httpmock::Method::POST;
 use httpmock::MockServer;
 use httpmock::prelude::HttpMockRequest;
 use qqqa::ai::ChatClient;
-use std::net::TcpListener;
 use serde_json::Value;
+use std::net::TcpListener;
 
 fn sandbox_blocks_binding() -> bool {
     TcpListener::bind("127.0.0.1:0").is_err()
@@ -73,11 +73,15 @@ async fn chat_once_uses_new_parameters_for_new_models() {
                     .body
                     .as_ref()
                     .expect("expected request body for new model");
-                let payload: Value = serde_json::from_slice(body)
-                    .expect("request body should be valid JSON");
+                let payload: Value =
+                    serde_json::from_slice(body).expect("request body should be valid JSON");
                 assert!(payload.get("max_completion_tokens").is_some());
                 assert!(payload.get("max_tokens").is_none());
                 assert!(payload.get("temperature").is_none());
+                assert_eq!(
+                    payload.get("reasoning_effort").and_then(|v| v.as_str()),
+                    Some("minimal")
+                );
                 true
             });
         then.status(200)
@@ -106,11 +110,18 @@ async fn chat_once_uses_legacy_parameters_for_old_models() {
                     .body
                     .as_ref()
                     .expect("expected request body for legacy model");
-                let payload: Value = serde_json::from_slice(body)
-                    .expect("request body should be valid JSON");
-                assert_eq!(payload.get("max_tokens").and_then(|v| v.as_u64()), Some(4000));
+                let payload: Value =
+                    serde_json::from_slice(body).expect("request body should be valid JSON");
+                assert_eq!(
+                    payload.get("max_tokens").and_then(|v| v.as_u64()),
+                    Some(4000)
+                );
                 assert!(payload.get("max_completion_tokens").is_none());
-                assert_eq!(payload.get("temperature").and_then(|v| v.as_f64()), Some(0.0));
+                assert_eq!(
+                    payload.get("temperature").and_then(|v| v.as_f64()),
+                    Some(0.0)
+                );
+                assert!(payload.get("reasoning_effort").is_none());
                 true
             });
         then.status(200)
@@ -120,6 +131,42 @@ async fn chat_once_uses_legacy_parameters_for_old_models() {
 
     let client = ChatClient::new(server.base_url(), "test".into()).unwrap();
     let got = client.chat_once("gpt-4.1-mini", "Hi", false).await.unwrap();
+    assert_eq!(got, "ok");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn chat_once_respects_reasoning_override_when_configured() {
+    if sandbox_blocks_binding() {
+        eprintln!("[skip] sandbox blocks binding to 127.0.0.1; skipping httpmock test");
+        return;
+    }
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat/completions")
+            .matches(|req: &HttpMockRequest| {
+                let body = req
+                    .body
+                    .as_ref()
+                    .expect("expected request body for override model");
+                let payload: Value =
+                    serde_json::from_slice(body).expect("request body should be valid JSON");
+                assert_eq!(
+                    payload.get("reasoning_effort").and_then(|v| v.as_str()),
+                    Some("high")
+                );
+                true
+            });
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"choices":[{"message":{"content":"ok"}}]}"#);
+    });
+
+    let client = ChatClient::new(server.base_url(), "test".into())
+        .unwrap()
+        .with_reasoning_effort(Some("high".to_string()));
+    let got = client.chat_once("gpt-5-mini", "Hi", false).await.unwrap();
     assert_eq!(got, "ok");
     mock.assert();
 }


### PR DESCRIPTION
Fixed support for "newer" OpenAI models like o1, o3 and gpt-5.
In addition to that, added support for reasoning effort - by default set to `minimal` to make sure `qqqa` works fast and does not get in the way.