### PR TITLE
Increase qq and qa timeout, make timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Defaults written to `~/.qq/config.json`:
   - `ollama` → model `llama3.1`
   - `anthropic` → model `claude-3-5-sonnet-20241022` (inactive placeholder until Anthropic integration lands)
 - Optional per-profile `reasoning_effort` for GPT-5 family models. If you leave it unset, qqqa sends `"reasoning_effort": "minimal"` for any `gpt-5*` model to keep responses fast. Set it to `"low"`, `"medium"`, or `"high"` when you want deeper reasoning.
+- (discouraged): you can change the timeout, e.g. `"timeout": "240"` under a model profile in `~/.qq/config.json` to raise the per-request limit (`qq` + `qa` default to 180 s - this is SLOW; faster models are a better fix).
 
 Example override in `~/.qq/config.json`:
 

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 const DEFAULT_MAX_COMPLETION_TOKENS: u32 = 4000;
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 180;
+const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 
 /// Minimal OpenAI-compatible chat streaming delta payload
 #[derive(Debug, Deserialize)]
@@ -99,11 +101,14 @@ impl ChatClient {
         base_url: String,
         api_key: String,
         headers: HashMap<String, String>,
+        request_timeout_secs: Option<u64>,
     ) -> Result<Self> {
         // Use rustls for TLS; set useful timeouts for robustness.
+        let timeout =
+            Duration::from_secs(request_timeout_secs.unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS));
         let client = Client::builder()
-            .timeout(Duration::from_secs(60))
-            .connect_timeout(Duration::from_secs(10))
+            .timeout(timeout)
+            .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
             .build()?;
         let mut default_headers = HeaderMap::new();
         for (name, value) in headers {

--- a/src/bin/qa.rs
+++ b/src/bin/qa.rs
@@ -155,6 +155,7 @@ async fn main() -> Result<()> {
         eff.base_url.clone(),
         eff.api_key.clone(),
         eff.headers.clone(),
+        eff.request_timeout_secs,
     )?
     .with_reasoning_effort(eff.reasoning_effort.clone());
     // Provide tool specs so the API can emit structured tool_calls instead of erroring.

--- a/src/bin/qq.rs
+++ b/src/bin/qq.rs
@@ -170,6 +170,7 @@ async fn main() -> Result<()> {
         eff.base_url.clone(),
         eff.api_key.clone(),
         eff.headers.clone(),
+        eff.request_timeout_secs,
     )?
     .with_reasoning_effort(eff.reasoning_effort.clone());
 

--- a/tests/ai_tests.rs
+++ b/tests/ai_tests.rs
@@ -5,6 +5,7 @@ use qqqa::ai::ChatClient;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::net::TcpListener;
+use std::time::{Duration, Instant};
 
 fn sandbox_blocks_binding() -> bool {
     TcpListener::bind("127.0.0.1:0").is_err()
@@ -24,7 +25,7 @@ async fn chat_once_non_streaming_parses_response() {
             .body(r#"{"choices":[{"message":{"content":"Hello world"}}]}"#);
     });
 
-    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new()).unwrap();
+    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new(), None).unwrap();
     let got = client.chat_once("model-x", "Hi", true).await.unwrap();
     assert_eq!(got, "Hello world");
     mock.assert();
@@ -49,7 +50,7 @@ async fn chat_stream_streams_tokens() {
             .body(sse_body);
     });
 
-    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new()).unwrap();
+    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new(), None).unwrap();
     let mut acc = String::new();
     client
         .chat_stream("model-x", "Hi", true, |tok| acc.push_str(tok))
@@ -90,7 +91,7 @@ async fn chat_once_uses_new_parameters_for_new_models() {
             .body(r#"{"choices":[{"message":{"content":"ok"}}]}"#);
     });
 
-    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new()).unwrap();
+    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new(), None).unwrap();
     let got = client.chat_once("gpt-5-mini", "Hi", false).await.unwrap();
     assert_eq!(got, "ok");
     mock.assert();
@@ -130,7 +131,7 @@ async fn chat_once_uses_legacy_parameters_for_old_models() {
             .body(r#"{"choices":[{"message":{"content":"ok"}}]}"#);
     });
 
-    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new()).unwrap();
+    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new(), None).unwrap();
     let got = client.chat_once("gpt-4.1-mini", "Hi", false).await.unwrap();
     assert_eq!(got, "ok");
     mock.assert();
@@ -164,7 +165,7 @@ async fn chat_once_respects_reasoning_override_when_configured() {
             .body(r#"{"choices":[{"message":{"content":"ok"}}]}"#);
     });
 
-    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new())
+    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new(), None)
         .unwrap()
         .with_reasoning_effort(Some("high".to_string()));
     let got = client.chat_once("gpt-5-mini", "Hi", false).await.unwrap();
@@ -196,8 +197,38 @@ async fn chat_client_sends_custom_headers() {
     );
     headers.insert("X-Title".to_string(), "qqqa".to_string());
 
-    let client = ChatClient::new(server.base_url(), "test".into(), headers).unwrap();
+    let client = ChatClient::new(server.base_url(), "test".into(), headers, None).unwrap();
     let got = client.chat_once("model-x", "Hi", false).await.unwrap();
     assert_eq!(got, "ok");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn chat_client_respects_timeout_override() {
+    if sandbox_blocks_binding() {
+        eprintln!("[skip] sandbox blocks binding to 127.0.0.1; skipping httpmock test");
+        return;
+    }
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .delay(Duration::from_secs(3))
+            .body(r#"{"choices":[{"message":{"content":"too slow"}}]}"#);
+    });
+
+    let client = ChatClient::new(server.base_url(), "test".into(), HashMap::new(), Some(1)).unwrap();
+    let start = Instant::now();
+    let err = client.chat_once("model-x", "Hi", false).await.unwrap_err();
+    let elapsed = start.elapsed();
+    assert!(elapsed < Duration::from_secs(3), "request was not capped by timeout: {:?}", elapsed);
+    let timed_out = err
+        .chain()
+        .any(|cause| {
+            let msg = cause.to_string();
+            msg.contains("deadline") || msg.contains("timed out")
+        });
+    assert!(timed_out, "unexpected error chain: {err:?}");
     mock.assert();
 }


### PR DESCRIPTION
Allow `qq` / `qa` requests to run up to 180 s by default while letting users override the timeout per profile via `~/.qq/config.json`. This is discouraged! Only adding it for advanced use cases.