### PR TITLE
Infra: Add windows support + artifact creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 - Source lives in `src/` with two binaries: `src/bin/qq.rs` and `src/bin/qa.rs`.
-- Core modules: `ai.rs`, `config.rs`, `prompt.rs`, `history.rs`, `perms.rs`, `formatting.rs`.
+- Core modules: `ai.rs`, `config.rs`, `prompt.rs`, `history.rs`, `perms.rs`, `formatting.rs`, `shell.rs`.
 - Tools for the agent live in `src/tools/` (`read_file.rs`, `write_file.rs`, `execute_command.rs`).
 - Integration tests live in `tests/`. Build artifacts are in `target/`.
 - Architecture notes: `src/lib.rs` re-exports the runtime modules and `src/tools/mod.rs` centralizes tool parsing/dispatch; refer to `README.md` for the high-level architecture and behavior overview.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ TARGETS="x86_64-apple-darwin aarch64-apple-darwin" scripts/release.sh v0.9.1
 
 What the script does
 - Bumps `Cargo.toml` version to the provided one (normalizes to SemVer).
-- Builds `qq` and `qa` for macOS (x86_64/arm64) and Linux MUSL (x86_64/arm64) by default; override `TARGETS` if needed.
+- Builds `qq` and `qa` for macOS (x86_64/arm64), Linux MUSL (x86_64/arm64), and Windows (x86_64 GNU + arm64 gnullvm) by default; override `TARGETS` if needed.
 - Packages `qqqa-v<version>-<target>.tar.gz` under `target/releases/v<version>/` with README and LICENSE.
 - Writes `target/releases/v<version>/manifest.json` for upload to GitHub Releases.
 - Downloads the GitHub tag archive (`https://github.com/iagooar/qqqa/archive/refs/tags/v<version>.tar.gz`), computes its SHA256, and rewrites `homebrew-tap/Formula/qqqa.rb` with the new URL/sha/version so the tap is always aligned.
@@ -63,6 +63,7 @@ What the script does
 Notes
 - Cross-compiling across OSes may require appropriate toolchains. The script runs `rustup target add` for the listed targets.
 - For static Linux builds, switch to `*-unknown-linux-musl` targets if your environment supports them.
+- Windows artifacts use MSVC targets on Windows hosts. When cross-compiling from macOS/Linux, we ship the x86_64 build via MinGW-w64 (`x86_64-pc-windows-gnu`, requires `x86_64-w64-mingw32-gcc`) and the arm64 build via llvm-mingw (`aarch64-pc-windows-gnullvm`, requires `aarch64-w64-mingw32-clang`). Install the corresponding toolchains (Homebrew `mingw-w64` plus an `llvm-mingw` bundle) before running the release script.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The two binaries are:
 - `qq` - ask a single question, e.g. "qq how can I recursively list all files in this directory" (qq stands for "quick question")
 - `qa` - a single step agent that can optionally use tools to finish a task: read a file, write a file, or execute a command with confirmation (qa stands for "quick agent")
 
+qqqa runs on macOS, Linux, and Windows.
+
 By default the repo includes profiles for OpenRouter (default), OpenAI, Groq, and a local Ollama runtime. An Anthropic profile stub exists in the config for future work but is not wired up yet.
 
 
@@ -66,6 +68,10 @@ brew install qqqa
 ### Linux
 
 Download a prebuilt archive from the [GitHub Releases](https://github.com/iagooar/qqqa/releases) page, extract it, and place `qq`/`qa` somewhere on your `PATH` (e.g., `/usr/local/bin`).
+
+### Windows
+
+Download the Windows archive from Releases (choose the architecture that matches your machine), extract `qq.exe` and `qa.exe`, and add them to your `%PATH%`.
 
 ## Configure
 
@@ -132,7 +138,6 @@ Example override in `~/.qq/config.json`:
 ### Terminal history
 
 Terminal history is **off by default**. During `qq --init` / `qa --init` you can opt in to sending the last 10 `qq`/`qa` commands along with each request. You can still override per run with `--history` (force on) or `-n/--no-history` (force off). Only commands whose first token is `qq` or `qa` are ever shared.
-
 
 ## Usage
 
@@ -247,13 +252,16 @@ qa --history "trace which git commands I ran recently"
 
 # disable emojis in responses (persists)
 qa --no-fun "format and lint the repo"
+
+# run qa non-interactively with confirmation already granted
+qa -y "count lines across *.rs"
 ```
 
 When qa runs a command while stdout is a terminal, output now streams live; the structured `[tool:execute_command]` summary still prints afterward for easy copying.
 
 `execute_command` prints the proposed command and asks for confirmation. It warns if the working directory is outside your home. Use `-y` to auto approve in trusted workflows.
 
-The runner enforces a default allowlist (think `ls`, `grep`, `find`, `rg`, `awk`, etc.) and rejects pipelines, redirection, and other high-risk constructs. When a command is blocked, `qa` prompts you to add it to `command_allowlist` inside `~/.qq/config.json`; approving once persists the choice and updates future runs.
+The runner enforces a default allowlist (think `ls`, `grep`, `find`, `rg`, `awk`, etc.) and rejects pipelines, redirection, and other high-risk constructs. When a command is blocked, `qa` prompts you to add it to `command_allowlist` inside `~/.qq/config.json`; approving once persists the choice and updates future runs. On Windows it automatically adapts to the active environment so built-ins like `dir` or `Get-ChildItem` keep working without extra flags.
 
 ## Advanced features and configurations
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,9 +11,9 @@ set -euo pipefail
 # Usage:
 #   scripts/release.sh v0.7.0 [<git_sha>] [TARGETS="..."]
 #
-# Defaults TARGETS depend on host OS and prefer MUSL for Linux cross-builds:
-#   - macOS: x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-musl aarch64-unknown-linux-musl
-#   - Linux: host triple from `rustc -vV` (GNU), plus darwin only if osxcross toolchains are present
+# Defaults TARGETS cover macOS, Linux MUSL, and Windows:
+#   - macOS/Linux hosts: macOS (x86_64/aarch64), Linux MUSL (x86_64/aarch64), Windows (x86_64/aarch64 via MinGW, zipped)
+#   - Windows hosts: Windows MSVC (x86_64/aarch64, zipped) plus Linux MUSL (x86_64/aarch64 tarballs)
 #
 # You can override with TARGETS to include cross targets, but ensure
 # cross C toolchains exist (e.g., aarch64-linux-musl-gcc or aarch64-linux-gnu-gcc).
@@ -38,14 +38,67 @@ git_sha=${2:-}
 
 # Compute sensible OS-aware defaults to avoid accidental cross builds
 host_os=$(uname -s)
-targets_default=(
-  x86_64-apple-darwin
-  aarch64-apple-darwin
+case "$host_os" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    windows_host=1
+    ;;
+  *)
+    windows_host=0
+    ;;
+esac
+
+if [[ $windows_host -eq 1 ]]; then
+  targets_default=(
+    x86_64-pc-windows-msvc
+    aarch64-pc-windows-msvc
+    x86_64-unknown-linux-musl
+    aarch64-unknown-linux-musl
+  )
+else
+  targets_default=(
+    x86_64-apple-darwin
+    aarch64-apple-darwin
+    x86_64-unknown-linux-musl
+    aarch64-unknown-linux-musl
+    x86_64-pc-windows-gnu
+    aarch64-pc-windows-gnullvm
+  )
+fi
+
+IFS=' ' read -r -a targets <<< "${TARGETS:-${targets_default[*]}}"
+
+required_targets_default=(
   x86_64-unknown-linux-musl
   aarch64-unknown-linux-musl
 )
 
-IFS=' ' read -r -a targets <<< "${TARGETS:-${targets_default[*]}}"
+IFS=' ' read -r -a required_targets <<< "${REQUIRED_TARGETS:-${required_targets_default[*]}}"
+
+# Ensure required targets are always present in the build list
+for rt in "${required_targets[@]}"; do
+  [[ -n "$rt" ]] || continue
+  found=0
+  for t in "${targets[@]}"; do
+    if [[ "$t" == "$rt" ]]; then
+      found=1
+      break
+    fi
+  done
+  if [[ $found -eq 0 ]]; then
+    targets+=("$rt")
+  fi
+done
+
+is_required_target() {
+  local needle="$1"
+  for rt in "${required_targets[@]}"; do
+    [[ -n "$rt" ]] || continue
+    if [[ "$rt" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 echo "==> Releasing version ${ver}"
 
@@ -63,7 +116,7 @@ fi
 echo "==> Building targets: ${targets[*]}"
 
 # Per-version directory for artifacts and manifest
-artifact_root="target/releases/v${ver}"
+artifact_root="${root_dir}/target/releases/v${ver}"
 mkdir -p "$artifact_root"
 manifest_dir="$artifact_root"
 
@@ -83,6 +136,10 @@ for t in "${targets[@]}"; do
       if [[ "$host_os" == "Darwin" ]]; then
         echo "          Tip: prefer MUSL targets on macOS (install: brew install FiloSottile/musl-cross/musl-cross)" >&2
       fi
+      if is_required_target "$t"; then
+        echo "          ERROR: target $t is required; install the toolchain or override REQUIRED_TARGETS." >&2
+        exit 1
+      fi
       echo "          Skipping $t." >&2
       continue
     fi
@@ -95,6 +152,10 @@ for t in "${targets[@]}"; do
       echo "    WARN: Missing MUSL cross toolchain: $cc_tool (required by ring)." >&2
       if [[ "$host_os" == "Darwin" ]]; then
         echo "          Install via Homebrew: brew install FiloSottile/musl-cross/musl-cross" >&2
+      fi
+      if is_required_target "$t"; then
+        echo "          ERROR: target $t is required; install the toolchain or override REQUIRED_TARGETS." >&2
+        exit 1
       fi
       echo "          Skipping $t." >&2
       continue
@@ -119,12 +180,42 @@ for t in "${targets[@]}"; do
     fi
     cc_tool="$found"
     linker_tool="$found"
+  elif [[ "$t" == *"-pc-windows-gnullvm"* ]]; then
+    arch_prefix=$(echo "$t" | sed -E 's/-pc-windows-gnullvm$//')
+    cc_tool="${arch_prefix}-w64-mingw32-clang"
+    linker_tool="$cc_tool"
+    if ! command -v "$cc_tool" >/dev/null 2>&1; then
+      echo "    WARN: Missing LLVM MinGW toolchain: $cc_tool." >&2
+      if is_required_target "$t"; then
+        echo "          ERROR: target $t is required; install llvm-mingw ($cc_tool) or override REQUIRED_TARGETS." >&2
+        exit 1
+      fi
+      echo "          Skipping $t." >&2
+      continue
+    fi
+  elif [[ "$t" == *"-pc-windows-gnu"* ]]; then
+    arch_prefix=$(echo "$t" | sed -E 's/-pc-windows-gnu$//')
+    cc_tool="${arch_prefix}-w64-mingw32-gcc"
+    linker_tool="$cc_tool"
+    if ! command -v "$cc_tool" >/dev/null 2>&1; then
+      echo "    WARN: Missing MinGW cross toolchain: $cc_tool." >&2
+      if is_required_target "$t"; then
+        echo "          ERROR: target $t is required; install mingw-w64 ($cc_tool) or override REQUIRED_TARGETS." >&2
+        exit 1
+      fi
+      echo "          Skipping $t." >&2
+      continue
+    fi
+  elif [[ "$t" == *"-pc-windows-msvc"* && $windows_host -eq 0 ]]; then
+    echo "    WARN: $t requires MSVC toolchains and can only be built on Windows hosts. Skipping." >&2
+    continue
   fi
 
   # If we have a cc/linker tool for this target, set env vars cargo/cc understands
   if [[ -n "$cc_tool" ]]; then
-    cc_var="CC_${t//-/_}"
-    linker_var="CARGO_TARGET_${t//-/_}_LINKER"
+    target_key=$(echo "${t//-/_}" | tr '[:lower:]' '[:upper:]')
+    cc_var="CC_${target_key}"
+    linker_var="CARGO_TARGET_${target_key}_LINKER"
     # shellcheck disable=SC2163
     export "$cc_var"="$cc_tool"
     # shellcheck disable=SC2163
@@ -135,31 +226,69 @@ for t in "${targets[@]}"; do
     echo "    Installing target $t via rustup..."
     rustup target add "$t"
   fi
-  RUSTFLAGS="${RUSTFLAGS:-}" cargo build --release --target "$t" || {
-    echo "    WARN: build failed for $t, skipping packaging" >&2
+  if ! RUSTFLAGS="${RUSTFLAGS:-}" cargo build --release --target "$t"; then
+    echo "    ERROR: build failed for $t" >&2
+    if is_required_target "$t"; then
+      exit 1
+    fi
+    echo "    WARN: skipping packaging for non-required target $t" >&2
     continue
-  }
+  fi
 
   outdir="${manifest_dir}/${t}"
   mkdir -p "$outdir"
   bin_dir="target/${t}/release"
-  cp -f "${bin_dir}/qq" "${outdir}/qq" || true
-  cp -f "${bin_dir}/qa" "${outdir}/qa" || true
+  for bin in qq qa; do
+    if [[ -f "${bin_dir}/${bin}.exe" ]]; then
+      cp -f "${bin_dir}/${bin}.exe" "${outdir}/${bin}.exe" || true
+    elif [[ -f "${bin_dir}/${bin}" ]]; then
+      cp -f "${bin_dir}/${bin}" "${outdir}/${bin}" || true
+    else
+      echo "    WARN: ${bin} binary not found for $t (looked in ${bin_dir})." >&2
+    fi
+  done
   # Include basic docs
   cp -f README.md "$outdir/README.md" || true
   cp -f LICENSE "$outdir/" 2>/dev/null || true
 
-  # Package tar.gz per target
-  tarball="${artifact_root}/qqqa-v${ver}-${t}.tar.gz"
-  tar -C "$outdir" -czf "$tarball" . 2>/dev/null || {
-    # Fallback: package what's available
-    echo "    Packaging whatever binaries are present for $t"
-    tar -C "$outdir" -czf "$tarball" .
-  }
+  if [[ "$t" == *"windows"* ]]; then
+    archive="${artifact_root}/qqqa-v${ver}-${t}.zip"
+    if command -v zip >/dev/null 2>&1; then
+      (cd "$outdir" && zip -qr "$archive" .)
+    else
+      echo "    WARN: zip not found; falling back to tar.gz for $t" >&2
+      archive="${artifact_root}/qqqa-v${ver}-${t}.tar.gz"
+      tar -C "$outdir" -czf "$archive" . 2>/dev/null || tar -C "$outdir" -czf "$archive" .
+    fi
+  else
+    archive="${artifact_root}/qqqa-v${ver}-${t}.tar.gz"
+    tar -C "$outdir" -czf "$archive" . 2>/dev/null || {
+      echo "    Packaging whatever binaries are present for $t"
+      tar -C "$outdir" -czf "$archive" .
+    }
+  fi
 
   # Cleanup per-target staging directory after packaging
   rm -rf "$outdir"
 done
+
+missing_required=0
+for rt in "${required_targets[@]}"; do
+  [[ -n "$rt" ]] || continue
+  if [[ "$rt" == *"windows"* ]]; then
+    artifact_path="${artifact_root}/qqqa-v${ver}-${rt}.zip"
+  else
+    artifact_path="${artifact_root}/qqqa-v${ver}-${rt}.tar.gz"
+  fi
+  if [[ ! -f "$artifact_path" ]]; then
+    echo "==> ERROR: required artifact not produced: ${artifact_path}" >&2
+    missing_required=1
+  fi
+done
+if [[ $missing_required -ne 0 ]]; then
+  echo "==> Aborting release because required targets failed to build." >&2
+  exit 1
+fi
 
 # Pack source tarball for Homebrew / manual uploads
 src_stage=$(mktemp -d)
@@ -169,56 +298,6 @@ src_tarball="${artifact_root}/qqqa-v${ver}-src.tar.gz"
 tar -C "$src_stage" -czf "$src_tarball" "$src_dir"
 rm -rf "$src_stage"
 src_sha=$(shasum -a 256 "$src_tarball" | awk '{print $1}')
-
-# Homebrew tap handling now relies on the GitHub tag archive (always available once the tag exists)
-tap_formula="homebrew-tap/Formula/qqqa.rb"
-tap_url="https://github.com/iagooar/qqqa/archive/refs/tags/v${ver}.tar.gz"
-tap_checksum_cmd=""
-if command -v shasum >/dev/null 2>&1; then
-  tap_checksum_cmd="shasum -a 256"
-elif command -v sha256sum >/dev/null 2>&1; then
-  tap_checksum_cmd="sha256sum"
-fi
-if [[ -f "$tap_formula" ]]; then
-  if ! command -v curl >/dev/null 2>&1; then
-    echo "==> WARN: curl not found; skipping Homebrew formula update." >&2
-  elif [[ -z "$tap_checksum_cmd" ]]; then
-    echo "==> WARN: no shasum/sha256sum available; skipping Homebrew formula update." >&2
-  else
-    tap_tmp=$(mktemp)
-    echo "==> Downloading ${tap_url} to compute Homebrew checksum"
-    if curl -fsSL "$tap_url" -o "$tap_tmp"; then
-      tap_sha=$($tap_checksum_cmd "$tap_tmp" | awk '{print $1}')
-      rm -f "$tap_tmp"
-      python3 <<PY
-from pathlib import Path
-import re
-
-formula = Path("$tap_formula")
-ver = "$ver"
-sha = "$tap_sha"
-url = "$tap_url"
-
-text = formula.read_text()
-text = re.sub(r'url "[^"]+"', f'url "{url}"', text)
-text = re.sub(r'sha256 "[^"]+"', f'sha256 "{sha}"', text)
-if 'version "' in text:
-    text = re.sub(r'version "[^"]+"', f'version "{ver}"', text)
-else:
-    text = text.replace(f'sha256 "{sha}"', f'sha256 "{sha}"\n  version "{ver}"', 1)
-
-formula.write_text(text)
-PY
-      echo "==> Updated Homebrew formula at $tap_formula"
-      echo "    Remember to commit and push the tap repository (homebrew-tap)."
-    else
-      echo "==> WARN: failed to download ${tap_url}; skipping Homebrew formula update." >&2
-      rm -f "$tap_tmp"
-    fi
-  fi
-else
-  echo "==> Skipping Homebrew formula update (homebrew-tap/Formula/qqqa.rb not found)."
-fi
 
 # Checksums and manifest
 checksum_cmd=""
@@ -241,7 +320,7 @@ echo "==> Writing manifest ${manifest_file}"
   fi
   echo "  \"artifacts\": ["
   first=1
-  for f in "${manifest_dir}"/qqqa-v${ver}-*.tar.gz; do
+  for f in "${manifest_dir}"/qqqa-v${ver}-*.tar.gz "${manifest_dir}"/qqqa-v${ver}-*.zip; do
     [[ -e "$f" ]] || continue
     name=$(basename "$f")
     csum=""
@@ -261,7 +340,104 @@ echo "==> Writing manifest ${manifest_file}"
   echo "}"
 } > "$manifest_file"
 
-echo "==> Done. Artifacts staged under ${artifact_root}/"
+echo "==> Phase 1 complete. Artifacts staged under ${artifact_root}/"
+echo "    Upload the following files to your GitHub release/tag before continuing:"
+for f in "${artifact_root}"/qqqa-v${ver}-*.tar.gz "$manifest_file"; do
+  [[ -e "$f" ]] || continue
+  echo "      - $f"
+done
+echo "    Attach them when running: gh release create v${ver} ..."
+echo
+
+skip_phase_two=0
+if [[ "${SKIP_PHASE2:-}" == "1" ]]; then
+  skip_phase_two=1
+elif [[ "${AUTO_CONTINUE:-}" == "1" ]]; then
+  echo "==> AUTO_CONTINUE=1 detected; proceeding to Phase 2 without waiting."
+else
+  if [[ -t 0 ]]; then
+    read -r -p $'Press enter once the artifacts are uploaded and the tag archive is live (type "skip" to stop after Phase 1): ' phase_resp || true
+    if [[ "$phase_resp" =~ ^[Ss][Kk][Ii][Pp]$ ]]; then
+      skip_phase_two=1
+    fi
+  else
+    echo "==> Non-interactive shell detected. Set AUTO_CONTINUE=1 to run both phases or SKIP_PHASE2=1 to finish early."
+    skip_phase_two=1
+  fi
+fi
+
+if [[ "$skip_phase_two" == "1" ]]; then
+  echo "==> Phase 2 (Homebrew tap update) skipped. Re-run this script with AUTO_CONTINUE=1 after publishing the GitHub release if needed."
+  exit 0
+fi
+
+# Homebrew tap handling now relies on the GitHub tag archive (always available once the tag exists)
+tap_formula="homebrew-tap/Formula/qqqa.rb"
+tap_url="https://github.com/iagooar/qqqa/archive/refs/tags/v${ver}.tar.gz"
+tap_checksum_cmd=""
+if command -v shasum >/dev/null 2>&1; then
+  tap_checksum_cmd="shasum -a 256"
+elif command -v sha256sum >/dev/null 2>&1; then
+  tap_checksum_cmd="sha256sum"
+fi
+if [[ -f "$tap_formula" ]]; then
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "==> WARN: curl not found; skipping Homebrew formula update." >&2
+  elif [[ -z "$tap_checksum_cmd" ]]; then
+    echo "==> WARN: no shasum/sha256sum available; skipping Homebrew formula update." >&2
+  else
+    tap_update_done=0
+    tap_attempt=1
+    while [[ $tap_update_done -eq 0 ]]; do
+      tap_tmp=$(mktemp)
+      echo "==> Downloading ${tap_url} to compute Homebrew checksum (attempt ${tap_attempt})"
+      if curl -fsSL "$tap_url" -o "$tap_tmp"; then
+        tap_sha=$($tap_checksum_cmd "$tap_tmp" | awk '{print $1}')
+        rm -f "$tap_tmp"
+        python3 <<PY
+from pathlib import Path
+import re
+
+formula = Path("$tap_formula")
+ver = "$ver"
+sha = "$tap_sha"
+url = "$tap_url"
+
+text = formula.read_text()
+text = re.sub(r'url "[^"]+"', f'url "{url}"', text)
+text = re.sub(r'sha256 "[^"]+"', f'sha256 "{sha}"', text)
+if 'version "' in text:
+    text = re.sub(r'version "[^"]+"', f'version "{ver}"', text)
+else:
+    text = text.replace(f'sha256 "{sha}"', f'sha256 "{sha}"\n  version "{ver}"', 1)
+
+formula.write_text(text)
+PY
+        echo "==> Updated Homebrew formula at $tap_formula"
+        echo "    Remember to commit and push the tap repository (homebrew-tap)."
+        tap_update_done=1
+      else
+        rm -f "$tap_tmp"
+        echo "==> WARN: failed to download ${tap_url}; GitHub may still be processing the release." >&2
+        if [[ -t 0 ]]; then
+          read -r -p $'Press enter to retry once the archive is available, or type "skip" to bypass the tap update: ' retry_resp || true
+          if [[ "$retry_resp" =~ ^[Ss][Kk][Ii][Pp]$ ]]; then
+            echo "==> Skipping Homebrew formula update by request."
+            break
+          fi
+        else
+          echo "==> WARN: non-interactive shell; skipping Homebrew formula update." >&2
+          break
+        fi
+      fi
+      tap_attempt=$((tap_attempt + 1))
+    done
+  fi
+else
+  echo "==> Skipping Homebrew formula update (homebrew-tap/Formula/qqqa.rb not found)."
+fi
+
+echo "==> Done. Artifacts remain under ${artifact_root}/"
 echo "==> Next steps"
 cat <<EOF
   1. Review README/docs for accuracy (update manually if needed).
@@ -278,10 +454,7 @@ fi
 cat <<EOF
   4. Push code and tag:
        git push && git push --tags
-  5. Publish GitHub release (after push):
-       gh release create v${ver} target/releases/v${ver}/qqqa-v${ver}-*.tar.gz \\
-         target/releases/v${ver}/qqqa-v${ver}-src.tar.gz target/releases/v${ver}/manifest.json \\
-         --title "qqqa v${ver}" --notes-file docs/RELEASE_NOTES_TEMPLATE.md
+  5. Publish (or update) the GitHub release with the artifacts listed above if you haven't already.
   6. Update the Homebrew tap repo:
        (cd homebrew-tap && git add Formula/qqqa.rb && git commit -m 'qqqa v${ver}' && git push)
   7. Announce the release / publish notes as needed.

--- a/src/bin/qq.rs
+++ b/src/bin/qq.rs
@@ -8,6 +8,7 @@ use qqqa::formatting::{
 };
 use qqqa::history::read_recent_history;
 use qqqa::prompt::{build_qq_system_prompt, build_qq_user_message, coalesce_prompt_inputs};
+use qqqa::shell::{detect_shell, shell_hint_for_prompt};
 use std::ffi::OsString;
 use std::io::{Read, Stdin};
 
@@ -193,8 +194,16 @@ async fn main() -> Result<()> {
     if cfg.no_emoji_enabled() {
         system.push_str("\nHard rule: You MUST NOT use emojis anywhere in the response.\n");
     }
+    let os_details = os_info::get();
+    let os_type = os_details.os_type();
+    let shell_kind = detect_shell(os_type);
+    if cli.debug {
+        eprintln!("[debug] Inferred shell: {}", shell_kind.display_name(),);
+    }
+    let shell_hint = shell_hint_for_prompt(shell_kind);
     let user = build_qq_user_message(
-        Some(os_info::get().os_type()),
+        Some(os_type),
+        Some(shell_hint),
         &history,
         stdin_block.as_deref(),
         &question,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ pub mod formatting;
 pub mod history;
 pub mod perms;
 pub mod prompt;
+pub mod shell;
 pub mod tools;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,94 @@
+use os_info::Type as OsType;
+
+/// Shell flavors that qq/qa can target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellKind {
+    /// POSIX `sh -lc`, default on Unix.
+    Posix,
+    /// `cmd.exe /C`, default on Windows when unspecified.
+    CmdExe,
+    /// Windows PowerShell (`powershell.exe`/`pwsh`).
+    PowerShell,
+}
+
+impl ShellKind {
+    pub fn display_name(self) -> &'static str {
+        match self {
+            ShellKind::Posix => "POSIX sh",
+            ShellKind::CmdExe => "Windows cmd.exe",
+            ShellKind::PowerShell => "Windows PowerShell",
+        }
+    }
+}
+
+/// Infer the shell flavor based on the current OS and environment.
+pub fn detect_shell(os_type: OsType) -> ShellKind {
+    match os_type {
+        OsType::Windows => detect_windows_shell(),
+        _ => ShellKind::Posix,
+    }
+}
+
+fn detect_windows_shell() -> ShellKind {
+    let shell_env = std::env::var_os("SHELL")
+        .map(|val| val.to_string_lossy().to_ascii_lowercase());
+    let has_prompt = std::env::var_os("PROMPT").is_some();
+    let has_pwsh_markers = std::env::var_os("POWERSHELL_DISTRIBUTION_CHANNEL").is_some()
+        || std::env::var_os("WT_PROFILE_ID").is_some()
+        || std::env::var_os("PSMODULEPATH").is_some();
+    classify_windows_shell(shell_env, has_prompt, has_pwsh_markers)
+}
+
+fn classify_windows_shell(
+    shell_env_lower: Option<String>,
+    has_prompt: bool,
+    has_pwsh_markers: bool,
+) -> ShellKind {
+    if let Some(lower) = shell_env_lower {
+        if lower.contains("bash") || lower.contains("sh") {
+            return ShellKind::Posix;
+        }
+    }
+
+    if !has_prompt && has_pwsh_markers {
+        ShellKind::PowerShell
+    } else {
+        ShellKind::CmdExe
+    }
+}
+
+pub fn shell_hint_for_prompt(kind: ShellKind) -> &'static str {
+    match kind {
+        ShellKind::Posix => "POSIX-compatible sh",
+        ShellKind::CmdExe => "Windows cmd.exe",
+        ShellKind::PowerShell => "Windows PowerShell",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_windows_defaults_to_posix_even_when_prompt_true() {
+        assert_eq!(detect_shell(OsType::Linux), ShellKind::Posix);
+    }
+
+    #[test]
+    fn windows_posix_when_shell_env_mentions_bash() {
+        let result = classify_windows_shell(Some("/usr/bin/bash".into()), false, false);
+        assert_eq!(result, ShellKind::Posix);
+    }
+
+    #[test]
+    fn windows_powershell_when_only_ps_markers_present() {
+        let result = classify_windows_shell(None, false, true);
+        assert_eq!(result, ShellKind::PowerShell);
+    }
+
+    #[test]
+    fn windows_cmd_when_prompt_present_no_ps_markers() {
+        let result = classify_windows_shell(None, true, false);
+        assert_eq!(result, ShellKind::CmdExe);
+    }
+}

--- a/tests/history_prompt_tests.rs
+++ b/tests/history_prompt_tests.rs
@@ -53,8 +53,10 @@ fn history_reader_prefers_existing_files_and_limits() {
 fn prompt_builders_include_sections() {
     let hist = vec!["cmd1".to_string(), "cmd2".to_string()];
     let stdin_block = Some("input text\nline2");
+    let shell_hint = Some("POSIX sh");
     let qq = build_qq_prompt(
         Some(os_info::get().os_type()),
+        shell_hint,
         &hist,
         stdin_block,
         "What is Rust?",
@@ -67,6 +69,7 @@ fn prompt_builders_include_sections() {
     assert!(sys.contains("Available tools"));
     let user = build_qa_user_message(
         Some(os_info::get().os_type()),
+        shell_hint,
         &hist,
         stdin_block,
         "Do the thing",
@@ -87,8 +90,10 @@ fn coalesce_prompt_inputs_uses_piped_text_when_args_empty() {
     assert_eq!(question, "Show me the full contents of this directory");
     assert!(stdin_block.is_none());
 
+    let shell_hint = Some("POSIX sh");
     let prompt = qqqa::prompt::build_qq_prompt(
         Some(os_info::get().os_type()),
+        shell_hint,
         &[],
         stdin_block.as_deref(),
         &question,

--- a/tests/tools_tests.rs
+++ b/tests/tools_tests.rs
@@ -1,4 +1,5 @@
 use qqqa::perms::{clear_custom_allowlist, ensure_safe_path};
+use qqqa::shell::ShellKind;
 use qqqa::tools::parse_tool_call;
 use qqqa::tools::read_file;
 use qqqa::tools::write_file;
@@ -95,6 +96,7 @@ async fn execute_command_runs_and_captures_output() {
         },
         true,
         true,
+        ShellKind::Posix,
         None,
     )
     .await
@@ -121,6 +123,7 @@ async fn execute_command_honors_pty_force_flag() {
         },
         true,
         false,
+        ShellKind::Posix,
         None,
     )
     .await
@@ -137,6 +140,7 @@ async fn execute_command_honors_pty_force_flag() {
         },
         true,
         false,
+        ShellKind::Posix,
         None,
     )
     .await
@@ -174,6 +178,7 @@ async fn execute_command_respects_disable_flag() {
         },
         true,
         false,
+        ShellKind::Posix,
         None,
     )
     .await
@@ -191,6 +196,7 @@ async fn execute_command_respects_disable_flag() {
         },
         true,
         false,
+        ShellKind::Posix,
         None,
     )
     .await
@@ -231,6 +237,7 @@ async fn execute_command_streams_stdout_chunks() {
         },
         true,
         false,
+        ShellKind::Posix,
         Some(&mut printer),
     )
     .await


### PR DESCRIPTION
Fixes #12 

- Added support for Windows (x86_64 GNU + arm64 gnullvm).
- Under the hood, support added for `cmd.exe` and `PowerShell` (system auto-detects what shell it is using, and adjusts the system prompt accordingly, in order to make the LLM return a command suggestion that is aligned with the underlying shell and OS)

Disclaimer: I haven't managed yet to test the binaries on a real Windows machine. I have a x86_64 PC I will eventually use for testing, but no access to Windows on ARM. 

👉🏻 So if you happen to try one of the two versions, please open an issue and provide feedback if something is broken still!